### PR TITLE
Fixed KeyError for when raw Node data does not contain 'baseVersion'

### DIFF
--- a/gkeepapi/node.py
+++ b/gkeepapi/node.py
@@ -848,7 +848,7 @@ class Node(Element, TimestampsMixin):
         self.server_id = raw['serverId'] if 'serverId' in raw else self.server_id
         self.parent_id = raw['parentId']
         self._sort = raw['sortValue'] if 'sortValue' in raw else self.sort
-        self._version = raw['baseVersion']
+        self._version = raw['baseVersion']  if 'baseVersion' in raw else self._version
         self._text = raw['text'] if 'text' in raw else self._text
         self.timestamps.load(raw['timestamps'])
         self.settings.load(raw['nodeSettings'])


### PR DESCRIPTION
I encountered a case where the raw Node data did not contain the keyword 'baseVersion', causing the following error:

```
  File "/usr/local/lib/python3.6/site-packages/gkeepapi-0.10.3-py3.6.egg/gkeepapi/__init__.py", line 367, in login
    self.sync()
  File "/usr/local/lib/python3.6/site-packages/gkeepapi-0.10.3-py3.6.egg/gkeepapi/__init__.py", line 572, in sync
    self._parseNodes(changes['nodes'])
  File "/usr/local/lib/python3.6/site-packages/gkeepapi-0.10.3-py3.6.egg/gkeepapi/__init__.py", line 596, in _parseNodes
    node = _node.from_json(raw_node)
  File "/usr/local/lib/python3.6/site-packages/gkeepapi-0.10.3-py3.6.egg/gkeepapi/node.py", line 1419, in from_json
    node.load(raw)
  File "/usr/local/lib/python3.6/site-packages/gkeepapi-0.10.3-py3.6.egg/gkeepapi/node.py", line 1007, in load
    super(TopLevelNode, self).load(raw)
  File "/usr/local/lib/python3.6/site-packages/gkeepapi-0.10.3-py3.6.egg/gkeepapi/node.py", line 851, in load
    self._version = raw['baseVersion']
KeyError: 'baseVersion'
```

This pull request checks to see if `baseVersion` exists, and, if not, uses the default value. This seems to address the issue causing #18 