### PR TITLE
Improves solution for kiwiz/gkeepapi#19 by handling baseVersion str <-> int conversion

### DIFF
--- a/gkeepapi/node.py
+++ b/gkeepapi/node.py
@@ -856,7 +856,7 @@ class Node(Element, TimestampsMixin):
         self.server_id = raw['serverId'] if 'serverId' in raw else self.server_id
         self.parent_id = raw['parentId']
         self._sort = raw['sortValue'] if 'sortValue' in raw else self.sort
-        self._version = raw['baseVersion'] if 'baseVersion' in raw else self._version
+        self._version = int(raw['baseVersion']) if 'baseVersion' in raw else self._version
         self._text = raw['text'] if 'text' in raw else self._text
         self.timestamps.load(raw['timestamps'])
         self.settings.load(raw['nodeSettings'])
@@ -870,7 +870,7 @@ class Node(Element, TimestampsMixin):
         ret['parentId'] = self.parent_id
         ret['sortValue'] = self._sort
         if not self.moved and self._version > 0:
-            ret['baseVersion'] = self._version
+            ret['baseVersion'] = str(self._version)
         ret['text'] = self._text
         if self.server_id is not None:
             ret['serverId'] = self.server_id

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -243,6 +243,21 @@ class NodeTests(unittest.TestCase):
         self.assertTrue(n.dirty)
         # FIXME: Node is not done
 
+    def test_baseversion(self):
+        n = node.Node(type_=node.NodeType.List)
+        clean_node(n)
+        raw_n = n.save()
+
+        # simulate an upstream version (already existing) which is a string value
+        # presumably this will be an integer, but is that a safe assumption always?
+        raw_n['baseVersion'] = '99'
+
+        n.load(raw_n)
+        saved_n = n.save() # Verify that we handle our internal int rep -> string
+
+        self.assertEqual(saved_n['baseVersion'], '99')
+        
+
 class TestElement(node.Element, node.TimestampsMixin):
     def __init__(self):
         super(TestElement, self).__init__()


### PR DESCRIPTION
The raw protocol _baseVersion_ is a string and the internal representation is an int. This handles that conversion and adds some testing around it.

This raises a question if we should be using a number for a version or if it can be a string moving forward. It doesn't appear that we are ever incrementing or explicitly setting a value for a version other than initialization so maybe we want to leave it as an "opaque" str value?