### PR TITLE
fix Python 3.7 compatibility

### DIFF
--- a/gkeepapi/__init__.py
+++ b/gkeepapi/__init__.py
@@ -22,7 +22,7 @@ from . import exception
 logger = logging.getLogger('keep')
 
 try:
-    Pattern = re._pattern_type
+    Pattern = re._pattern_type # pylint: disable=protected-access
 except AttributeError:
     Pattern = re.Pattern
 
@@ -645,7 +645,7 @@ class Keep(object):
         return (node for node in self.all() if
             (query is None or (
                 (isinstance(query, six.string_types) and (query in node.title or query in node.text)) or
-                (isinstance(query, Pattern) and ( # pylint: disable=protected-access
+                (isinstance(query, Pattern) and (
                     query.search(node.title) or query.search(node.text)
                 ))
             )) and
@@ -733,7 +733,7 @@ class Keep(object):
 
         for label in self._labels.values():
             if (isinstance(query, six.string_types) and query == label.name.lower()) or \
-                (isinstance(query, Pattern) and query.search(label.name)): # pylint: disable=protected-access
+                (isinstance(query, Pattern) and query.search(label.name)):
                 return label
 
         return self.createLabel(query) if create and isinstance(query, six.string_types) else None

--- a/gkeepapi/__init__.py
+++ b/gkeepapi/__init__.py
@@ -21,6 +21,11 @@ from . import exception
 
 logger = logging.getLogger('keep')
 
+try:
+    Pattern = re._pattern_type
+except AttributeError:
+    Pattern = re.Pattern
+
 class APIAuth(object):
     """Authentication token manager"""
     def __init__(self, scopes):
@@ -640,7 +645,7 @@ class Keep(object):
         return (node for node in self.all() if
             (query is None or (
                 (isinstance(query, six.string_types) and (query in node.title or query in node.text)) or
-                (isinstance(query, re._pattern_type) and ( # pylint: disable=protected-access
+                (isinstance(query, Pattern) and ( # pylint: disable=protected-access
                     query.search(node.title) or query.search(node.text)
                 ))
             )) and
@@ -728,7 +733,7 @@ class Keep(object):
 
         for label in self._labels.values():
             if (isinstance(query, six.string_types) and query == label.name.lower()) or \
-                (isinstance(query, re._pattern_type) and query.search(label.name)): # pylint: disable=protected-access
+                (isinstance(query, Pattern) and query.search(label.name)): # pylint: disable=protected-access
                 return label
 
         return self.createLabel(query) if create and isinstance(query, six.string_types) else None


### PR DESCRIPTION
Python 3.7 removes re._pattern_type.

See https://github.com/python/cpython/pull/1646

Otherwise,
```
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/adamyi/notes_to_keep/notes_to_keep/notes_to_keep.py", line 57, in <module>
    main()
  File "/Users/adamyi/notes_to_keep/notes_to_keep/notes_to_keep.py", line 53, in main
    start(args)
  File "/Users/adamyi/notes_to_keep/notes_to_keep/notes_to_keep.py", line 49, in start
    gkeep.start(gaia, password, notes, num, pfx, no_time, no_label)
  File "/Users/adamyi/notes_to_keep/notes_to_keep/gkeep.py", line 66, in start
    label = createLabel(keep)
  File "/Users/adamyi/notes_to_keep/notes_to_keep/gkeep.py", line 49, in createLabel
    label = keep.createLabel(name)
  File "/usr/local/lib/python3.7/site-packages/gkeepapi/__init__.py", line 664, in createLabel
    if self.findLabel(name):
  File "/usr/local/lib/python3.7/site-packages/gkeepapi/__init__.py", line 686, in findLabel
    (isinstance(query, re._pattern_type) and query.search(label.name)): # pylint: disable=protected-access
AttributeError: module 're' has no attribute '_pattern_type'
```