### PR TITLE
added method for trashing notes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -253,6 +253,11 @@ The :py:meth:`node.TopLevelNode.delete` method marks the note for deletion::
     gnote.delete()
     glist.delete()
 
+To send the node to the trash instead::
+
+    gnote.trash()
+    glist.trash()
+
 Getting media
 -------------
 

--- a/gkeepapi/node.py
+++ b/gkeepapi/node.py
@@ -971,6 +971,10 @@ class TimestampsMixin(object):
         """
         return self.timestamps.trashed is not None and self.timestamps.trashed > NodeTimestamps.int_to_dt(0)
 
+    def trash(self):
+        """Mark the item as trashed."""
+        self.timestamps.trashed = datetime.datetime.utcnow()
+
     @property
     def deleted(self):
         """Get the deleted state.

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -361,6 +361,13 @@ class TimestampsMixinTests(unittest.TestCase):
         n.timestamps.trashed = node.NodeTimestamps.int_to_dt(1)
         self.assertTrue(n.trashed)
 
+    def test_trash(self):
+        n = TestElement()
+        n.trash()
+
+        self.assertTrue(n.timestamps.dirty)
+        self.assertTrue(n.timestamps.trashed > node.NodeTimestamps.int_to_dt(0))
+
     def test_delete(self):
         n = TestElement()
         n.delete()


### PR DESCRIPTION
I noticed that notes have a method for deletion: `note.delete()`, but there was no analogue for sending a note to the trash, which works the same way.