### PR TITLE
Renamed method List.sort to List.sort_items

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -237,9 +237,9 @@ To reposition an item (larger is closer to the top)::
 Sorting a List
 ^^^^^^^^^^^^^^
 
-Lists can be sorted via :py:meth:`node.List.sort`::
+Lists can be sorted via :py:meth:`node.List.sort_items`::
    # Sorts items alphabetically by default
-   glist.sort()
+   glist.sort_items()
 
 Indent/dedent List items
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gkeepapi/node.py
+++ b/gkeepapi/node.py
@@ -1421,7 +1421,7 @@ class List(TopLevelNode):
             )
         ])
 
-    def sort(self, key=attrgetter('text'), reverse=False):
+    def sort_items(self, key=attrgetter('text'), reverse=False):
         sorted_children = sorted(self._items(),
                                  key=key, reverse=reverse)
         sort_value = random.randint(1000000000, 9999999999)

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -534,7 +534,7 @@ class ListTests(unittest.TestCase):
         sub_b.dedent(sub_c)
         self.assertTrue(sub_c.dirty)
 
-    def test_sort(self):
+    def test_sort_items(self):
         n = node.List()
 
         sub_a = n.add('a', sort=3)
@@ -544,7 +544,7 @@ class ListTests(unittest.TestCase):
         sub_e = n.add('e', sort=2)
         sub_f = n.add('f', sort=4)
 
-        n.sort()
+        n.sort_items()
 
         self.assertEqual(sub_a.id, n.items[0].id)
         self.assertEqual(sub_b.id, n.items[1].id)
@@ -562,7 +562,7 @@ class ListTests(unittest.TestCase):
         sub_bd = sub_b.add('bd', sort=4)
         sub_bc = sub_b.add('bc', sort=3)
 
-        n.sort()
+        n.sort_items()
 
         self.assertEqual(sub_a.id, n.items[0].id)
         self.assertEqual(sub_aa.id, n.items[1].id)
@@ -577,7 +577,7 @@ class ListTests(unittest.TestCase):
         time_2 = n.add('test2')
         time_3 = n.add('test3')
 
-        n.sort(key=attrgetter('timestamps.created'), reverse=True)
+        n.sort_items(key=attrgetter('timestamps.created'), reverse=True)
 
         self.assertEqual(time_3.id, n.items[0].id)
         self.assertEqual(time_2.id, n.items[1].id)


### PR DESCRIPTION
0.12 and PR #92 added a sort method to the `List` class, for sorting its items in-place. List's parent, `Node`, [already had a sort property](https://github.com/kiwiz/gkeepapi/blob/350737d059aadebc98d18b3f69a4cfa5f41f9920/gkeepapi/node.py#L1069). For Lists and Notes, this controlled the overall sorted layout of the notes in keep's main view.

The change broke the following code of mine, which moves a note to the top of the collection (which is not the same as pinning the note):

```python
keep = Keep()

def sort_note_to_top(note: TopLevelNode):
    note.sort = max(int(node.sort) for node in keep.all()) + 1

# raises TypeError, as `node.sort` is now sometimes a function, not a property returning an int.
```

I could just use the internal `_sort` value and call `touch()` myself, as the property does, but that kind of makes the property superfluous. So instead....

This PR renames the new `List.sort` to `List.sort_items`, and updates the docs and tests too.

Renaming someone else's work is usually a faux pas, but since the name already changed once during the pull request, I just went ahead and moved it. I hope that's not too disruptive.

---

Last minute addendum: There's also a classmethod `List.items_sort`, just above `sort_items`. I wonder if those two methods could be integrated better. However, that's beyond the scope of this change, as submitted anyway.