### PR TITLE
Fix node.untrash()

### DIFF
--- a/gkeepapi/node.py
+++ b/gkeepapi/node.py
@@ -979,7 +979,7 @@ class TimestampsMixin(object):
 
     def untrash(self):
         """Mark the item as untrashed."""
-        self.timestamps.trashed = None
+        self.timestamps.trashed = self.timestamps.int_to_dt(0)
 
     @property
     def deleted(self):

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -391,6 +391,7 @@ class TimestampsMixinTests(unittest.TestCase):
         clean_node(n)
         n.trash()
 
+        self.assertTrue(n.trashed)
         self.assertTrue(n.timestamps.dirty)
         self.assertTrue(n.timestamps.trashed > node.NodeTimestamps.int_to_dt(0))
 
@@ -398,7 +399,7 @@ class TimestampsMixinTests(unittest.TestCase):
         n.untrash()
 
         self.assertTrue(n.timestamps.dirty)
-        self.assertIsNone(n.timestamps.trashed)
+        self.assertFalse(n.trashed)
 
     def test_delete(self):
         n = TestElement()


### PR DESCRIPTION
This call was working locally but failing to untrash the note in Google Keep. It looks like the API has changed.