### PR TITLE
Minor Python2 deprecation additions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,9 +50,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'gkeepapi'
-copyright = u'2017, Kai'
-author = u'Kai'
+project = 'gkeepapi'
+copyright = '2017, Kai'
+author = 'Kai'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -146,8 +146,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'gkeepapi.tex', u'gkeepapi Documentation',
-     u'Kai', 'manual'),
+    (master_doc, 'gkeepapi.tex', 'gkeepapi Documentation',
+     'Kai', 'manual'),
 ]
 
 
@@ -156,7 +156,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'gkeepapi', u'gkeepapi Documentation',
+    (master_doc, 'gkeepapi', 'gkeepapi Documentation',
      [author], 1)
 ]
 
@@ -167,10 +167,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'gkeepapi', u'gkeepapi Documentation',
+    (master_doc, 'gkeepapi', 'gkeepapi Documentation',
      author, 'gkeepapi', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-

--- a/gkeepapi/node.py
+++ b/gkeepapi/node.py
@@ -212,7 +212,7 @@ class Element(object):
         try:
             self._load(raw)
         except (KeyError, ValueError) as e:
-            raise exception.ParseException('Parse error in %s' % (type(self)), raw) from e
+            raise exception.ParseException(f'Parse error in {type(self)}', raw) from e
 
     def _load(self, raw):
         """Unserialize from raw representation. (Implementation logic)
@@ -1814,7 +1814,7 @@ class Blob(Node):
         except (KeyError, ValueError) as e:
             logger.warning('Unknown blob type: %s', _type)
             if DEBUG: # pragma: no cover
-                raise exception.ParseException('Parse error for %s' % (_type), raw) from e
+                raise exception.ParseException(f'Parse error for {_type}', raw) from e
             return None
         blob = bcls()
         blob.load(raw)
@@ -1923,7 +1923,7 @@ def from_json(raw):
     except (KeyError, ValueError) as e:
         logger.warning('Unknown node type: %s', _type)
         if DEBUG: # pragma: no cover
-            raise exception.ParseException('Parse error for %s' % (_type), raw) from e
+            raise exception.ParseException(f'Parse error for {_type}', raw) from e
         return None
     node = ncls()
     node.load(raw)

--- a/gkeepapi/node.py
+++ b/gkeepapi/node.py
@@ -1582,9 +1582,9 @@ class ListItem(Node):
         self.touch(True)
 
     def __str__(self):
-        return u'%s%s %s' % (
+        return '%s%s %s' % (
             '  ' if self.indented else '',
-            u'☑' if self.checked else u'☐',
+            '☑' if self.checked else '☐',
             self.text
         )
 


### PR DESCRIPTION
* Remove the u prefix from strings which is no longer needed
* Convert some str.format to fstrings, only where it makes sense