### PR TITLE
correct sort argument's type annotation when adding a subitem to a list

### DIFF
--- a/gkeepapi/node.py
+++ b/gkeepapi/node.py
@@ -1508,7 +1508,7 @@ class ListItem(Node):
         Args:
             text (str): The text.
             checked (bool): Whether this item is checked.
-            sort (int): Item id for sorting.
+            sort (Union[gkeepapi.node.NewListItemPlacementValue, int]): Item id for sorting or a placement policy.
         """
         if self.parent is None:
             raise exception.InvalidException('Item has no parent')


### PR DESCRIPTION
The `sort` argument for adding a top-level item to a list, `List.add()`, is annotated to accept both `int` and `NewListItemPlacementValue` values.

However, the `sort` argument for adding a sub-item to an existing item, `ListItem.add()`, is only annotated to accept `int`, which is making my type checker question my authority. It must be silenced.

This PR corrects that by adding the `NewListItemPlacementValue` option to the annotation.

🚀🚀🚀🚀🚀🚀🚀