### PR TITLE
deprecate py2: replace pylint with ruff, auto-improving lots of code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: lint test coverage build clean upload all
 
 lint:
-	pylint src
+	-ruff --fix src
+	black src
 
 test:
 	python3 -m unittest discover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,27 @@ dependencies = [
   "future >= 0.16.0",
 ]
 optional-dependencies = [
-  "pylint>=2.17.2",
   "black>=23.3.0",
+  "ruff>=0.0.260",
 ]
 
 
 [project.urls]
 "Homepage" = "https://github.com/kiwiz/gkeepapi"
 "Bug Tracker" = "https://github.com/kiwiz/gkeepapi/issues"
+
+
+[tool.black]
+target-version = ["py310"]
+
+[tool.ruff]
+target-version = "py310"
+select = [
+    # https://beta.ruff.rs/docs/rules/
+    "E",  # pycodestyle (on by ruff's default)
+    "F",  # Pyflakes (on by ruff's default)
+    "PL",  # pylint
+]
+ignore = [
+    "E501",  # line-too-long -- disabled as black takes care of this
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,13 @@ select = [
     # https://beta.ruff.rs/docs/rules/
     "E",  # pycodestyle (on by ruff's default)
     "F",  # Pyflakes (on by ruff's default)
+    "I",  # isort
+    "UP",  # pyupgrade
+    "C4",  # flake8-comprehensions
+    "PIE",  # flake8-pie
+    "SIM",  # flake8-simplify
     "PL",  # pylint
+    "RUF",  # ruff
 ]
 ignore = [
     "E501",  # line-too-long -- disabled as black takes care of this

--- a/src/gkeepapi/__init__.py
+++ b/src/gkeepapi/__init__.py
@@ -1199,7 +1199,7 @@ class Keep:
         # Find nodes that aren't in our internal nodes list and insert them.
         for node in list(self._nodes.values()):
             for child in node.children:
-                if not child.id in self._nodes:
+                if child.id not in self._nodes:
                     self._nodes[child.id] = child
 
         nodes = []

--- a/src/gkeepapi/__init__.py
+++ b/src/gkeepapi/__init__.py
@@ -1,24 +1,23 @@
-# -*- coding: utf-8 -*-
 """
 .. moduleauthor:: Kai <z@kwi.li>
 """
 
 __version__ = "1.0.0"
 
+import datetime
 import logging
+import random
 import re
 import time
-import datetime
-import random
-from typing import Callable, Iterator, Tuple, Any
-
+from collections.abc import Callable, Iterator
+from typing import Any
 from uuid import getnode as get_mac
 
 import gpsoauth
 import requests
 
-from . import node as _node
 from . import exception
+from . import node as _node
 
 logger = logging.getLogger(__name__)
 
@@ -160,9 +159,8 @@ class APIAuth:
             client_sig="38918a453d07199354f8b19af05ec6562ced5788",
         )
         # Bail if no token was returned.
-        if "Auth" not in res:
-            if "Token" not in res:
-                raise exception.LoginException(res.get("Error"))
+        if "Auth" not in res and "Token" not in res:
+            raise exception.LoginException(res.get("Error"))
 
         self._auth_token = res["Auth"]
         return self._auth_token
@@ -865,7 +863,7 @@ class Keep:
             and (  # Process the labels.
                 labels is None
                 or (not labels and not node.labels.all())
-                or (any((node.labels.get(i) is not None for i in labels)))
+                or (any(node.labels.get(i) is not None for i in labels))
             )
             and (colors is None or node.color in colors)  # Process the colors.
             and (pinned is None or node.pinned == pinned)  # Process the pinned state.
@@ -898,7 +896,7 @@ class Keep:
     def createList(
         self,
         title: str | None = None,
-        items: list[Tuple[str, bool]] | None = None,
+        items: list[tuple[str, bool]] | None = None,
     ) -> _node.List:
         """Create a new list and populate it. Any changes to the note will be uploaded when :py:meth:`sync` is called.
 
@@ -1062,7 +1060,7 @@ class Keep:
             logger.debug("Starting keep sync: %s", self._keep_version)
 
             # Collect any changes and send them up to the server.
-            labels_updated = any((i.dirty for i in self._labels.values()))
+            labels_updated = any(i.dirty for i in self._labels.values())
             changes = self._keep_api.changes(
                 target_version=self._keep_version,
                 nodes=[i.save() for i in self._findDirtyNodes()],

--- a/src/gkeepapi/exception.py
+++ b/src/gkeepapi/exception.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 .. moduleauthor:: Kai <z@kwi.li>
 """

--- a/src/gkeepapi/node.py
+++ b/src/gkeepapi/node.py
@@ -1463,11 +1463,7 @@ class TopLevelNode(Node):
 
     @property
     def dirty(self):
-        return (
-            super().dirty
-            or self.labels.dirty
-            or self.collaborators.dirty
-        )
+        return super().dirty or self.labels.dirty or self.collaborators.dirty
 
     @property
     def blobs(self):
@@ -1500,9 +1496,7 @@ class ListItem(Node):
     def __init__(
         self, parent_id=None, parent_server_id=None, super_list_item_id=None, **kwargs
     ):
-        super().__init__(
-            type_=NodeType.ListItem, parent_id=parent_id, **kwargs
-        )
+        super().__init__(type_=NodeType.ListItem, parent_id=parent_id, **kwargs)
         self.parent_item = None
         self.parent_server_id = parent_server_id
         self.super_list_item_id = super_list_item_id


### PR DESCRIPTION
Since the repo is being modernized, I figured I would direct some attention to [ruff](https://beta.ruff.rs/docs/), a single tool that replaces a huge portion of the python ecosystem's linting and auto-upgrade tools, while running 10-100x faster than most of them due to it being written in Rust.

I took the liberty of replacing `pylint` with ruff's equivalent rule `PL`, and enabled a bunch of optional rules for upgrading to modern python syntaxes (namely `isort`, `pyupgrade`, `flake8-comprehensions`, `flake8-pie`, `flake8-simplify`, `pylint`, and `ruff`'s own ruleset). Their [list of rules](https://beta.ruff.rs/docs/rules/) keeps growing, and you can enable more of them in `pyproject.toml`.

They don't (yet) reimplement `black`, so I disabled ruff's line-length complaint and let black handle it in the `Makefile` lint script.

Besides the 33 auto-fixed rule violations, there are 6 `PL` suggestions that probably don't need attention, but the line containing `F811 Redefinition` looks very important.

```bash
(gkeepapi) ~/gkeepapi>$ make
ruff --fix src
src/gkeepapi/__init__.py:234:33: PLR2004 Magic value used in comparison, consider replacing 401 with a constant variable
src/gkeepapi/__init__.py:621:9: F811 Redefinition of unused `update` from line 466
src/gkeepapi/__init__.py:676:9: PLR0913 Too many arguments to function call (6 > 5)
src/gkeepapi/__init__.py:703:9: PLR0913 Too many arguments to function call (6 > 5)
src/gkeepapi/__init__.py:815:9: PLR0913 Too many arguments to function call (8 > 5)
src/gkeepapi/__init__.py:1096:9: PLR0912 Too many branches (17 > 12)
Found 6 errors.
make: [Makefile:4: lint] Error 1 (ignored)
black src
All done! ✨ 🍰 ✨
3 files left unchanged.
```