### PR TITLE
Work around sync rate limits

### DIFF
--- a/src/gkeepapi/__init__.py
+++ b/src/gkeepapi/__init__.py
@@ -1081,6 +1081,7 @@ class Keep:
         # Fetch updates until we reach the newest version.
         while True:
             logger.debug("Starting keep sync: %s", self._keep_version)
+            iteration_start = time.time()
 
             # Collect any changes and send them up to the server.
             labels_updated = any(i.dirty for i in self._labels.values())
@@ -1112,6 +1113,11 @@ class Keep:
             # Check if there are more changes to retrieve.
             if not changes["truncated"]:
                 break
+
+            # Make sure we're not issuing requests too fast, to avoid hitting rate limits.
+            # Notably, there's a 150 requests per user per minute rate limit.
+            # Make sure we send 2 requests per second maximum.
+            time.sleep(max(0.5 - (time.time() - iteration_start), 0))
 
     def _parseTasks(self, raw: dict) -> None:
         pass


### PR DESCRIPTION
Sleep between sync requests to avoid hitting rate limits.

Notably, there's a 150 requests per user per minute, that is guaranteed to be reached when syncing a collection of thousands of notes from scratch on a reasonably fast connection:

```
gkeepapi.exception.APIException: {'code': 429, 'message': "Quota exceeded for quota metric 'Sync requests' and limit 'Sync requests per minute per user' of service 'notes-pa.googleapis.com' for consumer 'project_number:192748556389'.", 'errors': [{'message': "Quota exceeded for quota metric 'Sync requests' and limit 'Sync requests per minute per user' of service 'notes-pa.googleapis.com' for consumer 'project_number:192748556389'.", 'domain': 'global', 'reason': 'rateLimitExceeded'}], 'status': 'RESOURCE_EXHAUSTED', 'details': [{'@type': 'type.googleapis.com/google.rpc.ErrorInfo', 'reason': 'RATE_LIMIT_EXCEEDED', 'domain': 'googleapis.com', 'metadata': {'service': 'notes-pa.googleapis.com', 'quota_metric': 'notes-pa.googleapis.com/sync_requests', 'quota_limit': 'SyncsPerMinutePerProjectPerUser', 'consumer': 'projects/192748556389', 'quota_unit': '1/min/{project}/{user}', 'quota_location': 'global', 'quota_limit_value': '150'}}, {'@type': 'type.googleapis.com/google.rpc.Help', 'links': [{'description': 'Request a higher quota limit.', 'url': 'https://cloud.google.com/docs/quotas/help/request_increase'}]}]}
```

Add a `time.sleep()` in the `_sync_notes()` loop to ensure we send at most 2 requests per second, by sleeping if the loop iteration went faster than 0.5s. This simple logic only waits if needed, it does not slow the process down if requests are already taking more than 0.5s.
**However**, this logic does slow the sync process down for everyone, even for users that were not hitting rate limits beforehand. I believe the additional delay should be relatively unnoticeable for small collections, or at least manageable for medium-sized collections.

Ideally we could either:
- implement a smarter rate limit logic to ensure we only sleep once we reach the actual limit; or
- parse Google's 429 response to dynamically sleep when needed

The latter would be best, but both these solutions would require a much more advanced logic than this simple 2-lines change, so I'd say this is good enough for now.

Related: #103 and #126.