### PR TITLE
Fix createNote to return Note instead of Node

### DIFF
--- a/src/gkeepapi/__init__.py
+++ b/src/gkeepapi/__init__.py
@@ -900,7 +900,7 @@ class Keep:
 
     def createNote(
         self, title: str | None = None, text: str | None = None
-    ) -> _node.Node:
+    ) -> _node.Note:
         """Create a new managed note. Any changes to the note will be uploaded when :py:meth:`sync` is called.
 
         Args:


### PR DESCRIPTION
Consider the following:
```python
note = keep.createNote('title', 'text')
note.pinned = True
```
This shows a warning that `'Node' object has no attribute 'pinned'`. The object returned from `createNote` is actually a `Note` and has attribute `pinned`, so no error is raised. However, `createNote` should indicate that it returns a `Note` to avoid this warning.